### PR TITLE
README fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ it in your application using the following Maven dependency::
     <dependency>
 		<groupId>com.github.adejanovski</groupId>
 		<artifactId>cassandra-jdbc-wrapper</artifactId>
-		<version>2.1.9</version>
+		<version>3.0.0</version>
 	</dependency>
 
 Or get the `fat jar with all dependencies included <https://drive.google.com/folderview?id=0B7fwX0DqcWSTNzZianJrWDI2bHc&usp=sharing#list>`_.


### PR DESCRIPTION
I have almost missed the latest version of the driver that adds compatibility to Cassandra 3.x only due to the old version being stated in the installation instructions in the readme.
