### PR TITLE
Add possibility to set/get Timestamp fields as Long in queries

### DIFF
--- a/src/main/java/com/github/adejanovski/cassandra/jdbc/SessionHolder.java
+++ b/src/main/java/com/github/adejanovski/cassandra/jdbc/SessionHolder.java
@@ -26,11 +26,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.CodecRegistry;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SocketOptions;
 import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.core.policies.RoundRobinPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
+import com.github.adejanovski.cassandra.jdbc.codec.TimestampToLongCodec;
 
 import static com.github.adejanovski.cassandra.jdbc.Utils.*;
 
@@ -168,6 +170,12 @@ class SessionHolder {
             }
         }
 
+        CodecRegistry customizedRegistry = new CodecRegistry();
+        TimestampToLongCodec timestampCodec = new TimestampToLongCodec(Long.class);
+
+        customizedRegistry.register(timestampCodec);
+        builder.withCodecRegistry(customizedRegistry);
+        
         Cluster cluster = null;
         try {
             cluster = builder.build();

--- a/src/main/java/com/github/adejanovski/cassandra/jdbc/codec/TimestampToLongCodec.java
+++ b/src/main/java/com/github/adejanovski/cassandra/jdbc/codec/TimestampToLongCodec.java
@@ -1,0 +1,46 @@
+package com.github.adejanovski.cassandra.jdbc.codec;
+
+import java.nio.ByteBuffer;
+
+import org.apache.cassandra.utils.ByteBufferUtil;
+
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.ProtocolVersion;
+import com.datastax.driver.core.TypeCodec;
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+
+public class TimestampToLongCodec extends TypeCodec<Long> {
+
+	public TimestampToLongCodec(Class<Long> javaClass) {
+		super(DataType.timestamp(), javaClass);
+	}
+
+	@Override
+	public ByteBuffer serialize(Long paramT, ProtocolVersion paramProtocolVersion) throws InvalidTypeException {
+		if (paramT == null) {
+			return null;
+		}
+		return ByteBufferUtil.bytes(paramT);
+	}
+
+	@Override
+	public Long deserialize(ByteBuffer paramByteBuffer, ProtocolVersion paramProtocolVersion) throws InvalidTypeException {
+		if (paramByteBuffer == null) {
+			return null;
+
+		}
+		// always duplicate the ByteBuffer instance before consuming it!
+		return ByteBufferUtil.toLong(paramByteBuffer.duplicate());
+	}
+
+	@Override
+	public Long parse(String paramString) throws InvalidTypeException {
+		return Long.valueOf(paramString);
+	}
+
+	@Override
+	public String format(Long paramT) throws InvalidTypeException {
+		return String.valueOf(paramT);
+	}
+
+}

--- a/src/test/java/com/github/adejanovski/cassandra/jdbc/JdbcRegressionUnitTest.java
+++ b/src/test/java/com/github/adejanovski/cassandra/jdbc/JdbcRegressionUnitTest.java
@@ -1063,6 +1063,45 @@ public class JdbcRegressionUnitTest
     	con.isValid(-42);
     }
     
+    @Test
+    public void testTimestampToLongCodec() throws Exception
+    {
+    	System.out.println();
+        System.out.println("Test testTimestampToLongCodec");
+        System.out.println("--------------");
+        
+    	Statement stmt = con.createStatement();
+        java.util.Date now = new java.util.Date();
+                        
+        String createCF = "CREATE COLUMNFAMILY testTimestampToLongCodec (timestamp_col1 timestamp PRIMARY KEY, timestamp_col2 timestamp, text_value text);";
+        
+        stmt.execute(createCF);
+        stmt.close();
+        
+        String insert = "insert into testTimestampToLongCodec (timestamp_col1, timestamp_col2, text_value) values (?, ?, ?);";
+        PreparedStatement pstatement = con.prepareStatement(insert);
+        
+        pstatement.setObject(1, now.getTime()); // timestamp as long
+        pstatement.setObject(2, new Timestamp(now.getTime())); // timestamp as timestamp
+        pstatement.setString(3, "text_value"); // just text value
+        
+        pstatement.execute();
+        pstatement.close();
+        
+        String select = "select * from testTimestampToLongCodec;";
+        
+        PreparedStatement statement = con.prepareStatement(select);
+        ResultSet resultSet = statement.executeQuery();
+        
+        Assert.assertTrue(resultSet.next());
+        
+        Assert.assertEquals(resultSet.getLong("timestamp_col1"), now.getTime());
+        Assert.assertEquals(resultSet.getTimestamp("timestamp_col2"), new Timestamp(now.getTime()));
+        Assert.assertEquals(resultSet.getString("text_value"), "text_value");
+        
+        statement.close();
+        
+    }
     
     private final String  showColumn(int index, ResultSet result) throws SQLException
     {


### PR DESCRIPTION
This feature allows to set/get timestamp column in table using simple Long value. It can be useful when you have not direct control over queries and result interpretation as if you using driver in frameworks like WSO2.

Now you can use both variants in setting:
pstatement.setObject(11, new Timestamp(now.getTime()));
pstatement.setObject(11, now.getTime());

and getting of timestamps:
Long res1 = resultSet.getLong("timestamp_col1");
Timestamp res2 = resultSet.getTimestamp("timestamp_col2");

https://datastax.github.io/java-driver/manual/custom_codecs/
